### PR TITLE
Goes to an empty state after the last item in the list is scored

### DIFF
--- a/estimate-api/Doist.Estimate.Api/Hubs/EstimateHub.cs
+++ b/estimate-api/Doist.Estimate.Api/Hubs/EstimateHub.cs
@@ -49,7 +49,7 @@ namespace Doist.Estimate.Api.Hubs
                     request.SprintId,
                     request.WorkItemId));
 
-        public Task ChangeActiveWorkItem(ChangeActiveWorkitemRequest request)
+        public Task ChangeActiveWorkItem(ChangeActiveWorkItemRequest request)
             => ExecuteSprintEstimationOperation(
                 request,
                 sprintEstimationService => sprintEstimationService.ChangeActiveWorkItem(

--- a/estimate-api/Doist.Estimate.Api/Hubs/Requests/ChangeActiveWorkitemRequest.cs
+++ b/estimate-api/Doist.Estimate.Api/Hubs/Requests/ChangeActiveWorkitemRequest.cs
@@ -1,7 +1,7 @@
 ﻿namespace Doist.Estimate.Api.Hubs.Requests
 {
-    public class ChangeActiveWorkitemRequest : RequestBase
+    public class ChangeActiveWorkItemRequest : RequestBase
     {
-        public int WorkItemId { get; set; }
+        public int? WorkItemId { get; set; }
     }
 }

--- a/estimate-web/src/components/UserStoryList.jsx
+++ b/estimate-web/src/components/UserStoryList.jsx
@@ -123,8 +123,10 @@ class UserStoryList extends Component {
         if (viewSelectionId !== selectedUserStoryId) {
             selection.setAllSelected(false);
 
-            const viewIndexToSelect = _.findIndex(items, x => x.id === selectedUserStoryId);
-            selection.setIndexSelected(viewIndexToSelect, true, true);
+            if (selectedUserStoryId) {
+                const viewIndexToSelect = _.findIndex(items, x => x.id === selectedUserStoryId);
+                selection.setIndexSelected(viewIndexToSelect, true, true);
+            }
         }
 
         return (

--- a/estimate-web/src/components/pages/EstimatePage.jsx
+++ b/estimate-web/src/components/pages/EstimatePage.jsx
@@ -163,9 +163,11 @@ class EstimationSession extends Component {
             x => !x.storyPoints
         );
 
-        if (nextWorkItem) {
-            dispatch(requestSwitchActiveWorkItem(iterationPath, userId, nextWorkItem.id));
-        }
+        dispatch(requestSwitchActiveWorkItem(
+            iterationPath,
+            userId,
+            nextWorkItem ? nextWorkItem.id : null
+        ));
     }
 
     resetEstimate() {
@@ -223,6 +225,11 @@ class EstimationSession extends Component {
         const selectedWorkItem = selectedWorkItemId !== null
             ? _.find(workItems, x => x.id === selectedWorkItemId)
             : null;
+
+        console.log(`selectedWorkItemId ${selectedWorkItemId}`);
+        console.log(`selectedWorkItem ${selectedWorkItem}`);
+        console.log(`activeWorkItemId ${activeWorkItemId}`);
+
 
         const isSelectedWorkItemInEstimation = activeWorkItemId != null
             && selectedWorkItemId === activeWorkItemId;


### PR DESCRIPTION
Resolves #10 . After the last applicable work item is scored, transitions the UI to the default state with empty screens